### PR TITLE
Ajustes no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ listas onde você poderá postar sua vaga:
 - [Vagas para desenvolvedores no Ceará](https://github.com/CangaceirosDevels/vagas_de_emprego)
 - [Vagas para desenvolvedores iOS e OSX](https://github.com/CocoaHeadsBrasil/vagas)
 - [Vagas pra desenvolvedores PHP](https://github.com/phpdevbr/vagas)
-- [Vagas pra desenvolvedores Stone Pagamentos](https://github.com/stone-pagamentos/vagas)
 - [Vagas pra desenvolvedores React e React Native](https://github.com/react-brasil/vagas)
 - [Vagas para desenvolvedores Vue.js](https://github.com/vuejs-br/vagas)
 
 
- 
+
 ## Licença
 
 [MIT](/LICENSE) &copy; FrontendBR

--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ listas onde você poderá postar sua vaga:
 - [Open Source](https://github.com/frontendbr/open-source)
 - [Front-End Week](https://github.com/frontendbr/frontendweek)
 - [Sugestões](https://github.com/frontendbr/sugestoes)
+- [Survey](https://github.com/frontendbr/survey)

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ Vagas disponíveis em https://github.com/frontendbr/vagas/issues
 
 ### Cadastrando uma vaga
 
-Abra uma **issue** e, no titulo desta _issue_, coloque o nome da cidade entre colchetes seguido do nome da vaga e nome da empresa.
+1. Abra uma **issue** e, no titulo desta _issue_, coloque o nome da cidade entre colchetes seguido do nome da vaga e nome da empresa.
 
 Exemplo: `[São Paulo] Front-End Developer na [NOME DA EMPRESA]`
 
-Informe quais _labels_ devemos adicionar, contendo o nível de experiência desejada e a forma de contração.
+2. Informe quais _labels_ devemos adicionar, contendo o nível de experiência desejada e a forma de contração.
 
 **Atenção**: Não aceitaremos vagas sem o nome da empresa contratante.
 
 #### Importante
 
-1- Para evitar que possíveis candidatos enviem cvs para vagas já preenchidas, dê manutenção à sua issue, a cada 14 dias (2 semanas) coloque um comentário que continua procurando para a vaga ou feche a mesma comentando se a pessoa foi contratada através do nosso grupo ou por fora. Caso a issue passe de 14 dias e não tiver manutenção, a mesma poderá ser fechada por um moderador do repositório.
+1. Para evitar que possíveis candidatos enviem cvs para vagas já preenchidas, dê manutenção à sua issue, a cada 14 dias (2 semanas) coloque um comentário que continua procurando para a vaga ou feche a mesma comentando se a pessoa foi contratada através do nosso grupo ou por fora. Caso a issue passe de 14 dias e não tiver manutenção, a mesma poderá ser fechada por um moderador do repositório.
 
-2- Se a vaga está pendente de informação e/ou fora do padrão especificado no [modelo da issue](https://github.com/frontendbr/vagas/blob/master/.github/issue_template.md), um dos moderadores ou administradores poderá fechar a issue. Ela pode ser reaberta a qualquer momento, desde que tenha sido devidamente preenchida.
+2. Se a vaga está pendente de informação e/ou fora do padrão especificado no [modelo da issue](https://github.com/frontendbr/vagas/blob/master/.github/issue_template.md), um dos moderadores ou administradores poderá fechar a issue. Ela pode ser reaberta a qualquer momento, desde que tenha sido devidamente preenchida.
 
 ### Siga nosso Twitter <img src="https://cloud.githubusercontent.com/assets/3603793/18564664/f0a4eb36-7b62-11e6-83f8-4eaebee644b0.png" alt="Twitter" width="30" />
 
@@ -45,8 +45,6 @@ listas onde você poderá postar sua vaga:
 - [Vagas pra desenvolvedores PHP](https://github.com/phpdevbr/vagas)
 - [Vagas pra desenvolvedores React e React Native](https://github.com/react-brasil/vagas)
 - [Vagas para desenvolvedores Vue.js](https://github.com/vuejs-br/vagas)
-
-
 
 ## Licença
 


### PR DESCRIPTION
**Outros repositórios de vagas**

Removi o repositório da Stone Pagamentos, pois a lista que exibimos se refere à iniciativas que surgiram desse repositório de vagas seguindo alguns preceitos como:

- ser sobre vagas de uma stack específica (PHP, React.js, etc.);
- ser aberto pra vagas de qualquer empresa, seguindo as regras que temos.

Por ser um repo de uma empresa e conter posições diversas nas issues, acredito que não tenha motivo pra estar nessa lista do README.

**Survey**

Adiciona esse projeto sensacional, que o @LFeh subiu pra org do /frontendbr, na lista dos nossos repositórios.

**Ajustes finos**

Pequenas alterações de new lines sobrando e marcadores errados