### PR TITLE
Label automática nas vagas com GH Actions

### DIFF
--- a/.github/workflows/label-new-issue.yml
+++ b/.github/workflows/label-new-issue.yml
@@ -1,0 +1,16 @@
+# copiado de https://github.com/vuejs-br/vagas/blob/master/.github/workflows/label-new-issue.yml
+name: Labeling new issue
+
+on:
+    issues:
+        types: [opened]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps: 
+        - uses: Renato66/auto-label@v2.0.1
+          with:
+              repo-token: ${{ secrets.GITHUB_TOKEN }}
+              labels-not-allowed: "Fora dos padrões|Falta de informações"


### PR DESCRIPTION
Baseada [no repositório vuejs-br/vagas](https://github.com/vuejs-br/vagas/blob/master/.github/workflows/label-new-issue.yml).

Aparentemente é necessário o _token_ do Github de alguém para que funcione (vide o `${{ secrets.GITHUB_TOKEN }}` abaixo).