### PR TITLE
removendo link de vagas UX inválido e adicioando um novo com vagas atualizadas

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ listas onde você poderá postar sua vaga:
 
 - [Vagas para desenvolvedores Back-End](https://github.com/backend-br/vagas)
 - [Vagas para desenvolvedores Front-End](https://github.com/frontendbr/vagas)
-- [Vagas para UI/UX](https://github.com/uxbrasil/vagas)
+- [Vagas para UI/UX](https://github.com/remotejobsbr/design-ux-vagas)
 - [Vagas para QAs](https://github.com/qa-brasil/vagas)
 
 #### Por tecnologia


### PR DESCRIPTION
O link atual de vagas UX está quebrado (404), o repositório não existe mais. Este PR substitui o link quebrado por um com vagas atualizadas. 